### PR TITLE
Fix cost calculation

### DIFF
--- a/global.R
+++ b/global.R
@@ -125,10 +125,10 @@ tree_sim <- function(o_rows=24, #Block dimension row
                             bind_cols(expand_grid(x=c(1:o_cols),y=c(1:o_rows)),value=as.vector(tree)) %>%
                             add_column(
                               time=start_year + cntr - 1,
-                              cost_per_year_per_tree=yearly_cost/numel(orc_mat),
+                              realized_costs=yearly_cost/numel(orc_mat),
                             )
                           }) %>%
-    mutate(net_returns=output_price*value - cost_per_year_per_tree)
+    mutate(net_returns=output_price*value - realized_costs)
   
   return(tree_health)
 }

--- a/global.R
+++ b/global.R
@@ -83,6 +83,7 @@ tree_sim <- function(o_rows=24, #Block dimension row
     
     #Grow trees subject to damage
     tree_shell[[t+1]] <- tree_shell[[t]] + grow_trees(age_shell[[t]]) - disease_shell[,,t]
+    tree_shell[[t+1]] <- pmax(zeros(o_rows, o_cols), tree_shell[[t+1]]) # set negative yields to zero
     
     #Propagate disease if disease spread has started
     if (t >= start_disease_year){

--- a/server.R
+++ b/server.R
@@ -73,7 +73,7 @@ shinyServer(function(input, output, session) {
     output$orchard_health <- renderPlot({
       #Raster blocks with color indicating disease spread
       tree_health() %>%
-        dplyr::select(-ends_with("net_returns")) %>%
+        dplyr::select(-ends_with(c("net_returns", "cost_per_year_per_tree"))) %>%
         dplyr::filter(time==current_year()) %>%
         mutate(across(-c(x,y,time),~./`Max Yield`)) %>%
         dplyr::select(-`Max Yield`) %>%
@@ -106,7 +106,7 @@ shinyServer(function(input, output, session) {
 
       #Plot of block growth
       tree_health() %>%
-        dplyr::select(-ends_with("net_returns")) %>%
+        dplyr::select(-ends_with(c("net_returns", "cost_per_year_per_tree"))) %>%
         mutate(across(-c(x,y,time),~ifelse(.<0,0,.))) %>%
         group_by(time) %>%
         summarize(across(-c(x,y),~sum(.,na.rm = T))) %>%
@@ -123,34 +123,27 @@ shinyServer(function(input, output, session) {
     })
 
     output$mytable <- DT::renderDataTable({
+      tree_health_negatives_removed <- tree_health() %>%
+        mutate(across(-c(x,y,time),~ifelse(.<0,0,.))) %>%
+        group_by(time) %>%
+        summarize(across(-c(x,y),~sum(.,na.rm = T))) %>%
+        ungroup()
       DT::datatable(bind_rows(
                     #Row 1: yield
-                    tree_health() %>%
-                      mutate(across(-c(x,y,time),~ifelse(.<0,0,.))) %>%
-                      group_by(time) %>%
-                      summarize(across(-c(x,y),~sum(.,na.rm = T))) %>%
-                      ungroup() %>%
+                    tree_health_negatives_removed %>%
                       summarize(across(-c(time),~mean(.,na.rm = T))) %>%
                       mutate(across(everything(),~comma(.,accuracy=1))) %>%
                       select(`Max Yield`,`No Treatment`,`Treatment 1`,`Treatment 2`) %>%
                       add_column(`Economic Result`="Yield (avg/ac/yr)",.before = 1),
                     #Row 2: net returns
-                    tree_health() %>%
-                      mutate(across(-c(x,y,time),~ifelse(.<0,0,.))) %>%
-                      group_by(time) %>%
-                      summarize(across(-c(x,y),~sum(.,na.rm = T))) %>%
-                      ungroup() %>%
+                    tree_health_negatives_removed %>%
                       summarize(across(-c(time),~sum(.,na.rm = T))) %>%
                       mutate(across(everything(),~dollar(.,accuracy=1))) %>%
                       select(ends_with("net_returns")) %>%
                       rename(`Max Yield`=max_net_returns,`No Treatment`=nt_net_returns,`Treatment 1`=t1_net_returns,`Treatment 2`=t2_net_returns) %>%
                       add_column(`Economic Result`="Net Returns (avg/ac/yr)",.before = 1),
                     #Row 3: benefit of treatment
-                    tree_health() %>%
-                      mutate(across(-c(x,y,time),~ifelse(.<0,0,.))) %>%
-                      group_by(time) %>%
-                      summarize(across(-c(x,y),~sum(.,na.rm = T))) %>%
-                      ungroup() %>%
+                    tree_health_negatives_removed %>%
                       summarize(across(-c(time),~sum(.,na.rm = T))) %>%
                       mutate(t1_net_returns=t1_net_returns-nt_net_returns,
                              t2_net_returns=t2_net_returns-nt_net_returns,

--- a/server.R
+++ b/server.R
@@ -165,8 +165,8 @@ shinyServer(function(input, output, session) {
                     #Row 3: benefit of treatment
                     tree_health_aggregated_orchard_cost_yield_and_returns %>%
                       summarize(across(-c(time),~sum(.,na.rm = T)), n_years=n()) %>%
-                      mutate(t1_net_returns=(`Treatment 1`-`No Treatment`)*output_price()/n_years,
-                             t2_net_returns=(`Treatment 2`-`No Treatment`)*output_price()/n_years,
+                      mutate(t1_net_returns=(t1_net_returns - nt_net_returns)/n_years,
+                             t2_net_returns=(t2_net_returns - nt_net_returns)/n_years,
                              across(everything(),~dollar(.,accuracy=1))) %>%
                       select(ends_with("net_returns")) %>%
                       rename(`Max Yield`=max_net_returns,`No Treatment`=nt_net_returns,`Treatment 1`=t1_net_returns,`Treatment 2`=t2_net_returns) %>%


### PR DESCRIPTION
In the original cost calculations, there were two problems. 
First, the yields were allowed to decrease below zero. This created a problem where the net returns were multiplying negative yields by the price of peaches and then subtracting costs. 

Second, the yields were not normalized by the number of years.

Next improvements to the table will be to calculate the net present value of the yield from the year of treatment, and update the optimal replanting year by updating 1) the function governing the yield and 2) calculating when the orchard should be entirely replanted.