### PR TITLE
Update orchard to be replantable

### DIFF
--- a/server.R
+++ b/server.R
@@ -48,14 +48,14 @@ shinyServer(function(input, output, session) {
   )
 
   #Run simulations within reactive element
-  start_year <- reactive(input$year_start)
+  start_year <- reactive(input$time_horizon[1])
   current_year <- reactive(start_year() + input$year - 1)
   output_price <- reactive(input$output_price)
   
   tree_health_data <- reactive({
     simulateControlScenarios(
       year_start = start_year(),
-      year_end = input$year_end,
+      year_end = input$time_horizon[2],
       start_disease_year = input$start_disease_year,
       disease_spread_rate = input$disease_spread_rate/100, # function expects a percentage (fraction)
       disease_growth_rate = input$disease_growth_rate/100,
@@ -63,7 +63,9 @@ shinyServer(function(input, output, session) {
       output_price = output_price(),
       annual_cost = input$annual_cost,
       replanting_strategy = input$replanting_strategy,
+      replant_year = input$replant_year_orchard,
       replant_cost_tree = input$replant_cost_tree,
+      replant_cost_orchard = input$replant_cost_orchard,
       inf_intro = input$inf_intro,
       control1 = input$control1/100,
       t1_cost = input$t1_cost,

--- a/ui.R
+++ b/ui.R
@@ -21,7 +21,7 @@ ui <- tabsetPanel(
     includeCSS(path = "static/css/styles.css"), 
     tags$div(
       class="landing_page_div",
-      tags$h1(class="landing_page_h1", "Cytospora Decision Support Tool"),
+      tags$h1(class="landing_page_h1", "Disease Decision Tool: Cytospora"),
       fluidRow(
         column(
           width=6,
@@ -29,7 +29,7 @@ ui <- tabsetPanel(
         ),
         column(
           width=6,
-          tags$p("Welcome to CSU's Cytospora Decision Support Tool. This tool is meant
+          tags$p("Welcome to CSU's Disease Decision Support Tool. This tool is meant
                to aid peach farmers understand the economic impact of the cytospora 
                disease and control strategies."),
         )
@@ -64,12 +64,11 @@ ui <- tabsetPanel(
                              min = 0,
                              max = 100,
                              value=10),
-                numericInput("year_start",
-                             "Planting Year",
-                             2022),
-                numericInput("year_end",
-                             "Planned Replanting Year",
-                             2062),
+                sliderInput("time_horizon", 
+                            "Years to Run Simulation",
+                            min = 2000, 
+                            max = 2100, 
+                            value = c(2022, 2062)),
                 numericInput("annual_cost",
                              "Annual Production Cost ($/ac/yr)",
                              value=5885),
@@ -79,10 +78,15 @@ ui <- tabsetPanel(
                 selectInput("replanting_strategy",
                              label = "Dead Tree Replanting Strategy", 
                              choices = list("Don't replant" = 'no_replant', 
-                                            "Replant dead trees every year" = 'yr1_replant'),
-                                            # "Replant dead trees every 5 years" = 'yr5_replant',
+                                            "Replant dead trees every year" = 'tree_replant',
+                                            "Replant orchard at planned replanting year" = 'orchard_replant'),
                                             # "Replant dead trees every 10 years" = 'yr10_replant'),
-                             selected = 'no_replant'),
+                             selected = 'orchard_replant'),
+                sliderInput("replant_year_orchard",
+                             "Planned Replanting Year",
+                             value=20,
+                             min=1,
+                             max=40),
                 numericInput("replant_cost_tree",
                              "Tree Replanting Cost",
                              10),


### PR DESCRIPTION
This PR allows the user to specify when to replant the orchard. There is no randomness in how the disease starts or spreads, so the dynamics are exactly the same before and after the replanting. 

When dead tree replanting strategy is to "Replant orchard at planned replanting year":
<img width="900" alt="image" src="https://user-images.githubusercontent.com/20567775/197857786-b0bff5c4-457a-4f7f-b776-ac25eb42a14f.png">

If the user expands the simulation to more years, a future improvement is to automatically generate orchard replantings until the end of the simulation (at fixed and optimal years). 
