### PR TITLE
Added irr calculation

### DIFF
--- a/server.R
+++ b/server.R
@@ -432,10 +432,10 @@ shinyServer(function(input, output, session) {
                       add_column(`Economic Result`="Optimal First Replanting Year",.before = 1),
                     #Row 6: IRR
                     data.frame(`Economic Result`="Internal Rate of Return",
-                               `Treatment 1` = percent(coalesce(irr(tree_health_aggregated_orchard_cost_yield_and_returns$t1_net_returns), NA)),
-                               `Treatment 2` = percent(coalesce(irr(tree_health_aggregated_orchard_cost_yield_and_returns$t2_net_returns), NA)),
-                               `No Treatment`= percent(coalesce(irr(tree_health_aggregated_orchard_cost_yield_and_returns$nt_net_returns), NA)),
-                               `Disease Free`= percent(coalesce(irr(tree_health_aggregated_orchard_cost_yield_and_returns$max_net_returns), NA)),
+                               `Treatment 1` = percent(coalesce(irr(tree_health_aggregated_orchard_cost_yield_and_returns$t1_net_returns, r.guess=0.05), NA)),
+                               `Treatment 2` = percent(coalesce(irr(tree_health_aggregated_orchard_cost_yield_and_returns$t2_net_returns, r.guess=0.05), NA)),
+                               `No Treatment`= percent(coalesce(irr(tree_health_aggregated_orchard_cost_yield_and_returns$nt_net_returns, r.guess=0.05), NA)),
+                               `Disease Free`= percent(coalesce(irr(tree_health_aggregated_orchard_cost_yield_and_returns$max_net_returns, r.guess=0.05), NA)),
                                check.names=FALSE)
                     ),
                     options = list(dom = 't',


### PR DESCRIPTION
This PR calculates the IRR for each orchard scenario, using the `irr` [function](https://www.rdocumentation.org/packages/jrvFinance/versions/1.4.3/topics/irr) from the `jrvFinance` package. 

There are a few [other versions](https://www.rdocumentation.org/packages/FinancialMath/versions/0.1.1/topics/IRR) of the irr that are calucated using the `polyroot` function, which returns as many estimates for the irr as there are changes in sign of the net returns. Since for the orchard there are many changes in sign (every time the orchard is replanted), this ends up being a rather naive way to estimate the irr and seems to overestimate the irr (consistently around ~40% with those methods vs. ~25% with the irr function). 
<img width="616" alt="image" src="https://user-images.githubusercontent.com/20567775/218293849-9e72faf4-0618-479c-857e-ea307f1c492a.png">