### PR TITLE
Connect to Google sheets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 rsconnect
 .Rhistory
+.Rprofile
+scripts/gargle

--- a/scripts/gs_connect.R
+++ b/scripts/gs_connect.R
@@ -1,0 +1,31 @@
+library(googlesheets4)
+
+add_data_to_data_store <- function(data_to_add, settings_or_results_db='settings'){
+  sheet_id <- case_when(
+    # Note that this accesses the local and production data from the .Rprofile file 
+    # (not in file management for security reasons)
+    getOption("env")=="production" ~ getOption("prod_google_sheet_id")[[settings_or_results_db]],
+    getOption("env")=="local"      ~ getOption("local_google_sheet_id")[[settings_or_results_db]]
+  )
+  
+  if (gs4_has_token()==TRUE){
+    sheet_append(sheet_id, data_to_add)
+  }
+  else {
+    tryCatch(
+      {
+        gs4_auth(
+          email = gargle::gargle_oauth_email(),
+          path = NULL,
+          scopes = "https://www.googleapis.com/auth/spreadsheets",
+          cache = gargle::gargle_oauth_cache(), # cache points to a file path in .Rprofile with the manually generated Oauth token
+          use_oob = gargle::gargle_oob_default(),
+          token = NULL
+        )
+        sheet_append(sheet_id, data_to_add)
+      },
+      error=errorCondition("Authentication failed, or other error"),
+      finally =  print("Authentication succeeded.")
+    )
+  }
+}

--- a/server.R
+++ b/server.R
@@ -401,7 +401,7 @@ shinyServer(function(input, output, session) {
       )$value
       sum_roll_6 <- rollify(sum, window = 6)
       
-      output_data <<- bind_cols(
+      output_data <- bind_cols(
         #Col 1: yield
         data.frame(`Yield (avg/ac/yr)`=
           tree_health_aggregated_orchard_cost_yield_and_returns %>%
@@ -465,7 +465,7 @@ shinyServer(function(input, output, session) {
           check.names=FALSE)
       )
       
-      formatted_output_data <<- output_data %>%
+      formatted_output_data <- output_data %>%
         mutate(
           `Yield (avg/ac/yr)`=comma(`Yield (avg/ac/yr)`, accuracy=1),
           `Optimal First Replanting Year`=as.character(`Optimal First Replanting Year`),

--- a/server.R
+++ b/server.R
@@ -12,9 +12,10 @@ library(tidyverse)
 library(scales)
 library(shinyjqui)
 library(plotly)
-library(glue)
-library(tibbletime)
-library(jrvFinance)
+library(glue,       include.only = 'glue')
+library(tibbletime, include.only = 'rollify')
+library(jrvFinance, include.only = 'irr')
+source("scripts/gs_connect.R")
 
 shinyServer(function(input, output, session) {
   #  First input that is also updated by other inputs e.g. sum(annual_cost_{n})
@@ -216,8 +217,17 @@ shinyServer(function(input, output, session) {
   n_trees_in_orchard <- 576 # 24*24, number of trees planted in one acre
   max_yield <- reactive(input$max_yield/n_trees_in_orchard)
   
+  
+  last_t <- Sys.time()
+  check_enough_time_has_passed_since_last_run <- function(current_time=Sys.time(), 
+                                                          last_time=last_t){
+    tdiff <- difftime(current_time, last_time, units="secs")
+    tdiff <- as.numeric(tdiff, units="secs")
+    return(tdiff > 5)
+  }
+  
   tree_health_data <- reactive({
-    simulateControlScenarios(
+    simulation_inputs <- list(
       year_start = rv$start_year,
       year_end = rv$end_year + 1,
       t_disease_year = t_disease_year(),
@@ -242,11 +252,22 @@ shinyServer(function(input, output, session) {
       t2_cost = input$t2_cost,
       input_annual_price_change=input$percent_cost_change/100,
       output_annual_price_change=input$percent_price_change/100
-    )})
+    )
+    simulation_results <- do.call(simulateControlScenarios, simulation_inputs)
+    run_id <- rlang::hash(simulation_inputs)
+    ## Setup logging for simulation settings_changes
+    try({
+      if(check_enough_time_has_passed_since_last_run()){
+        # replant_years is a vector, causing a problem
+        simulation_inputs$replant_years <- paste(simulation_inputs$replant_years, collapse=',')
+        add_data_to_data_store(cbind(run_id=run_id, data.frame(simulation_inputs)))
+      }
+    })
+    return(list(data=simulation_results, id=run_id))})
   
     output$orchard_health <- renderPlotly({
       #Raster blocks with color indicating disease spread
-      data2 <- tree_health_data() %>%
+      data2 <- tree_health_data()$data %>%
         dplyr::select(-ends_with(c("net_returns", "realized_costs"))) %>%
         dplyr::filter(time==current_year()) %>%
         mutate(
@@ -336,7 +357,7 @@ shinyServer(function(input, output, session) {
       # if hovering, plot the tree's yield over time. If not hovering, plot the
       # table row selected, otherwise render the overall orchard yield.
       selected_row <- input$mytable_rows_selected
-      df <- tree_health_data() %>% select(-ends_with("tree_age"))
+      df <- tree_health_data()$data %>% select(-ends_with("tree_age"))
       
       if (!is.null(most_recent_x_y_hover())) {
         p <- plot_tree_yield(df, x_coord=most_recent_x_y_hover()[["x"]], y_coord=most_recent_x_y_hover()[["y"]])
@@ -365,7 +386,8 @@ shinyServer(function(input, output, session) {
     })
     
     output$mytable <- DT::renderDataTable({
-      tree_health_aggregated_orchard_cost_yield_and_returns <- tree_health_data() %>%
+      run_data_and_id <- tree_health_data()
+      tree_health_aggregated_orchard_cost_yield_and_returns <- run_data_and_id$data %>%
         select(-ends_with("tree_age")) %>%
         group_by(time) %>%
         summarize(across(-c(x,y),~sum(.,na.rm = T))) %>%
@@ -379,65 +401,90 @@ shinyServer(function(input, output, session) {
       )$value
       sum_roll_6 <- rollify(sum, window = 6)
       
-      DT::datatable(bind_rows(
-                    #Row 1: yield
-                    tree_health_aggregated_orchard_cost_yield_and_returns %>%
-                      summarize(across(-c(time),~mean(.,na.rm = T))) %>%
-                      mutate(across(everything(),~comma(.,accuracy=1))) %>%
-                      select(`Disease Free`,`No Treatment`,`Treatment 1`,`Treatment 2`) %>%
-                      add_column(`Economic Result`="Yield (avg/ac/yr)",.before = 1),
-                    #Row 2: net returns
-                    tree_health_aggregated_orchard_cost_yield_and_returns %>%
-                      summarize(across(-c(time),~mean(.,na.rm = T))) %>%
-                      mutate(across(everything(),~dollar(.,accuracy=1))) %>%
-                      select(ends_with("net_returns")) %>%
-                      rename(`Disease Free`=max_net_returns,`No Treatment`=nt_net_returns,`Treatment 1`=t1_net_returns,`Treatment 2`=t2_net_returns) %>%
-                      add_column(`Economic Result`="Net Returns (avg/ac/yr)",.before = 1),
-                    #Row 3: benefit of treatment
-                    tree_health_aggregated_orchard_cost_yield_and_returns %>%
-                      summarize(across(-c(time),~sum(.,na.rm = T)), n_years=n()) %>%
-                      mutate(t1_net_returns=(t1_net_returns - nt_net_returns)/n_years,
-                             t2_net_returns=(t2_net_returns - nt_net_returns)/n_years,
-                             across(everything(),~dollar(.,accuracy=1))) %>%
-                      select(ends_with("net_returns")) %>%
-                      rename(`Disease Free`=max_net_returns,`No Treatment`=nt_net_returns,`Treatment 1`=t1_net_returns,`Treatment 2`=t2_net_returns) %>%
-                      mutate(`Disease Free`="",
-                             `No Treatment`="") %>%
-                      add_column(`Economic Result`="Treatment Returns (avg/ac/yr)",.before = 1),
-                    #Row 4: net present value of returns at selected year
-                    tree_health_aggregated_orchard_cost_yield_and_returns %>%
-                      select(c(time, ends_with("net_returns"))) %>%
-                      filter(time >= current_year()) %>%
-                      # With a user-specified discount rate
-                      mutate(npv_multiplier=1/((1+input$percent_interest/100.0)**(time - current_year())),
-                             across(ends_with("net_returns"), ~(.*npv_multiplier), .names = "{.col}")) %>% 
-                      summarise(across(ends_with("net_returns"), ~dollar(sum(.),accuracy=1))) %>%
-                      rename(`Disease Free`=max_net_returns,`No Treatment`=nt_net_returns,`Treatment 1`=t1_net_returns,`Treatment 2`=t2_net_returns) %>%
-                      mutate(`Disease Free`="") %>%
-                      add_column(`Economic Result`="Net Present Value From Current Year ($/ac)", .before = 1),
-                    #Row 5: operating duration
-                    tree_health_aggregated_orchard_cost_yield_and_returns %>%
-                      filter((time > (rv$start_year + TREE_FIRST_FULL_YIELD_YEAR)) & (time < (rv$start_year + get_planting_years()[1]))) %>%
-                      # orders descending order so that the function cumsum sums starting from the end of the life of the orchard
-                      arrange(desc(time)) %>%
-                      mutate(across(ends_with("net_returns"), ~ifelse(n() >= 6, coalesce(sum_roll_6(.), cumsum(.)), NA), .names = "{.col}_cum")) %>%
-                      # chooses the first time the expected profit from the net returns is outweighed by the replanted yield
-                      # The plus one is to ensure that the year matches the year replanted (indexing problem)
-                      summarise(`Treatment 1` = as.character(first(time[t1_net_returns_cum  >= first_six_years_max_net_returns]) + 1),
-                                `Treatment 2` = as.character(first(time[t2_net_returns_cum  >= first_six_years_max_net_returns]) + 1),
-                                `No Treatment`= as.character(first(time[nt_net_returns_cum  >= first_six_years_max_net_returns]) + 1),
-                                `Disease Free`= as.character(first(time[max_net_returns_cum >= first_six_years_max_net_returns]) + 1)) %>%
-                      # TODO: decide if it makes sense or not to have the optimal replanting year when not replanting the entire orchard
-                      # mutate(across(everything(), ~ifelse(input$replanting_strategy %in% c('tree_replant'), "", .))) %>% 
-                      add_column(`Economic Result`="Optimal First Replanting Year",.before = 1),
-                    #Row 6: IRR
-                    data.frame(`Economic Result`="Internal Rate of Return",
-                               `Treatment 1` = percent(coalesce(irr(tree_health_aggregated_orchard_cost_yield_and_returns$t1_net_returns, r.guess=0.05), NA)),
-                               `Treatment 2` = percent(coalesce(irr(tree_health_aggregated_orchard_cost_yield_and_returns$t2_net_returns, r.guess=0.05), NA)),
-                               `No Treatment`= percent(coalesce(irr(tree_health_aggregated_orchard_cost_yield_and_returns$nt_net_returns, r.guess=0.05), NA)),
-                               `Disease Free`= percent(coalesce(irr(tree_health_aggregated_orchard_cost_yield_and_returns$max_net_returns, r.guess=0.05), NA)),
-                               check.names=FALSE)
-                    ),
+      output_data <<- bind_cols(
+        #Col 1: yield
+        data.frame(`Yield (avg/ac/yr)`=
+          tree_health_aggregated_orchard_cost_yield_and_returns %>%
+          summarize(across(-c(time),~mean(.,na.rm = T))) %>%
+          select(`Disease Free`,`No Treatment`,`Treatment 1`,`Treatment 2`) %>%
+          t(), check.names=FALSE),
+        #Col 2: net returns
+        data.frame(`Net Returns (avg/ac/yr)`=
+          tree_health_aggregated_orchard_cost_yield_and_returns %>%
+          summarize(across(-c(time),~mean(.,na.rm = T))) %>%
+          select(`Disease Free`=max_net_returns,`No Treatment`=nt_net_returns,`Treatment 1`=t1_net_returns,`Treatment 2`=t2_net_returns) %>%
+          t(), check.names=FALSE),
+        #Row 3: benefit of treatment
+        data.frame(`Treatment Returns (avg/ac/yr)`=
+          tree_health_aggregated_orchard_cost_yield_and_returns %>%
+          summarize(across(-c(time),~sum(.,na.rm = T)), n_years=n()) %>%
+          mutate(t1_net_returns=(t1_net_returns - nt_net_returns)/n_years,
+                 t2_net_returns=(t2_net_returns - nt_net_returns)/n_years) %>%
+          #select(ends_with("net_returns")) %>%
+          mutate(max_net_returns=NA) %>%
+          select(`Disease Free`=max_net_returns,`No Treatment`=nt_net_returns,`Treatment 1`=t1_net_returns,`Treatment 2`=t2_net_returns) %>%
+          #mutate(`Disease Free`=NA,
+          #       `No Treatment`=NA) %>%
+          t(), check.names = FALSE),
+        #Col 4: net present value of returns at selected year
+        data.frame(`Net Present Value From Current Year ($/ac)`=
+          tree_health_aggregated_orchard_cost_yield_and_returns %>%
+          select(c(time, ends_with("net_returns"))) %>%
+          filter(time >= current_year()) %>%
+          # With a user-specified discount rate
+          mutate(npv_multiplier=1/((1+input$percent_interest/100.0)**(time - current_year())),
+                 across(ends_with("net_returns"), ~(.*npv_multiplier), .names = "{.col}")) %>% 
+          summarise(across(ends_with("net_returns"), ~sum(.))) %>%
+          mutate(max_net_returns=NA) %>%
+          select(`Disease Free`=max_net_returns,`No Treatment`=nt_net_returns,`Treatment 1`=t1_net_returns,`Treatment 2`=t2_net_returns) %>%
+          #mutate(`Disease Free`=NA) %>%
+          t(), check.names = FALSE),
+        #Col 5: operating duration
+        data.frame(`Optimal First Replanting Year`=
+          tree_health_aggregated_orchard_cost_yield_and_returns %>%
+          filter((time > (rv$start_year + TREE_FIRST_FULL_YIELD_YEAR)) & (time < (rv$start_year + get_planting_years()[1]))) %>%
+          # orders descending order so that the function cumsum sums starting from the end of the life of the orchard
+          arrange(desc(time)) %>%
+          mutate(across(ends_with("net_returns"), ~ifelse(n() >= 6, coalesce(sum_roll_6(.), cumsum(.)), NA), .names = "{.col}_cum")) %>%
+          # chooses the first time the expected profit from the net returns is outweighed by the replanted yield
+          # The plus one is to ensure that the year matches the year replanted (indexing problem)
+          summarise(`Disease Free`= first(time[max_net_returns_cum >= first_six_years_max_net_returns]) + 1,
+                    `No Treatment`= first(time[nt_net_returns_cum  >= first_six_years_max_net_returns]) + 1,
+                    `Treatment 1` = first(time[t1_net_returns_cum  >= first_six_years_max_net_returns]) + 1,
+                    `Treatment 2` = first(time[t2_net_returns_cum  >= first_six_years_max_net_returns]) + 1) %>%
+          # TODO: decide if it makes sense or not to have the optimal replanting year when not replanting the entire orchard
+          # mutate(across(everything(), ~ifelse(input$replanting_strategy %in% c('tree_replant'), "", .))) %>%
+          t(), check.names = FALSE),
+        #Col 6: IRR
+        data.frame(`Internal Rate of Return`=c(
+            coalesce(irr(tree_health_aggregated_orchard_cost_yield_and_returns$max_net_returns, r.guess=0.05), NA),
+            coalesce(irr(tree_health_aggregated_orchard_cost_yield_and_returns$nt_net_returns, r.guess=0.05), NA),
+            coalesce(irr(tree_health_aggregated_orchard_cost_yield_and_returns$t1_net_returns, r.guess=0.05), NA),
+            coalesce(irr(tree_health_aggregated_orchard_cost_yield_and_returns$t2_net_returns, r.guess=0.05), NA)),
+          row.names=c("Disease Free", "No Treatment", "Treatment 1", "Treatment 2"),
+          check.names=FALSE)
+      )
+      
+      formatted_output_data <<- output_data %>%
+        mutate(
+          `Yield (avg/ac/yr)`=comma(`Yield (avg/ac/yr)`, accuracy=1),
+          `Optimal First Replanting Year`=as.character(`Optimal First Replanting Year`),
+          `Internal Rate of Return`=percent(`Internal Rate of Return`, accuracy=1),
+          across(c(`Net Returns (avg/ac/yr)`, `Treatment Returns (avg/ac/yr)`,`Net Present Value From Current Year ($/ac)`), ~dollar(., accuracy=1)),
+          ) %>% 
+        rownames_to_column("Economic Outcome") %>%
+        t() %>% data.frame() %>% rownames_to_column()
+      names(formatted_output_data) <- c("Economic Outcome", "Disease Free", "No Treatment", "Treatment 1", "Treatment 2")
+      
+      if (check_enough_time_has_passed_since_last_run()) {
+        add_data_to_data_store(
+          output_data %>%
+            rownames_to_column("Treatment Condition") %>% 
+            mutate(run_id=tree_health_data()$id, .before=1),
+          'results')
+      }
+      
+      DT::datatable(formatted_output_data[-1, ],
                     options = list(dom = 't',
                                    columnDefs = list(
                                      list(width = '40px', targets = 0),


### PR DESCRIPTION
This PR adds a connection to Google sheets to gather data on all of the parameters changed by users and the outcome of each simulation. 

Changed the datatable calculation to be column wise so that I could keep all of the data in one table without coercing everything to strings first. (Any data that is sent to the google sheet should be numeric).

I write to two sheets: an input sheet and an output sheet. The input sheet is a collection of all of the input parameters to the simulation, along with a unique id `run_id` that hashes all of the simulation inputs. This allows you to easily remove simulations ran with the same parameters. 

<img width="1398" alt="image" src="https://user-images.githubusercontent.com/20567775/222026991-961b0d86-e024-4bfc-9d18-bfd910770386.png">

The output sheet is the simulation output, four rows per simulation (Disease Free, No Treatment, Treatment 1, Treatment 2) for the same set of parameters. This sheet also has the run_id, so you can join it to the input data sheet. 

<img width="1232" alt="image" src="https://user-images.githubusercontent.com/20567775/222029450-6599dbc1-8f2b-4213-b695-e6f9501a4fdb.png">


Note: this does make the simulation quite a bit slower. I will look into seeing if I can send the data with something like a [promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) (aka asynchoronous and lazy evaluation). 