### PR TITLE
Removed multiple simulations and made the sheets connection asynchronous

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ rsconnect
 .Rhistory
 .Rprofile
 scripts/gargle
+.DS_Store
+.Rproj.user/
+cytospora.Rproj
+scripts/.DS_Store


### PR DESCRIPTION
There was quite a bit of lag in the previous deployment of the app. This PR solves this in two ways:

1. Removing the second call to the simulation code (`tree_health_data()`) which was accidentally called a second time inside a reactive element.
   1.1. This caused some circulatory code calling (any reactive element should only be called once per `observe` function)
   1.2. This also led to the simulation running an extra unnecessary time
2. Adds a `promise` to the code that spins up a new R thread to run the code that connects to the google sheets (or database in future iterations) instead of running it in sequence. This allows the app to connect to google and send data without interrupting the immediacy or interactivity of the app. 